### PR TITLE
Add better errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "framer-motion": "^6.5.1",
         "fuzzysort": "^2.0.4",
         "mongodb": "^4.15.0",
-        "next": "^13.3.0",
+        "next": "13.3.0",
         "next-auth": "^4.22.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "next-auth": "^4.22.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "sharp": "^0.32.0",
         "tabler-icons-react": "^1.56.0",
         "zod": "^3.21.4"
     },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "framer-motion": "^6.5.1",
         "fuzzysort": "^2.0.4",
         "mongodb": "^4.15.0",
-        "next": "latest",
+        "next": "^13.3.0",
         "next-auth": "^4.22.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,6 +19,9 @@
     .label {
         @apply pointer-events-none select-none p-1 text-xs font-normal uppercase text-gray-500;
     }
+    .error {
+        @apply pl-3 pt-1 text-xs font-semibold text-error-500;
+    }
 }
 
 /* ===== Scrollbar CSS ===== */

--- a/src/modules/protocol/elements/inputs/currency-input.tsx
+++ b/src/modules/protocol/elements/inputs/currency-input.tsx
@@ -13,10 +13,10 @@ const CurrencyInput = ({
     return (
         <div className="relative">
             <label className="label">{label}</label>
-            <div className="pointer-events-none absolute top-8 mt-0.5 pt-px left-0 flex items-center">
-                <span className="text-sm text-gray-400 ml-3">$</span>
+            <div className="pointer-events-none absolute left-0 top-8 mt-0.5 flex items-center pt-px">
+                <span className="ml-3 text-sm text-gray-400">$</span>
             </div>
-            <div className="pointer-events-none absolute top-8 mt-1 right-3 flex items-center">
+            <div className="pointer-events-none absolute right-3 top-8 mt-1 flex items-center">
                 <span className="text-sm text-gray-400">ARS</span>
             </div>
             <input
@@ -36,9 +36,7 @@ const CurrencyInput = ({
                 autoComplete="off"
             />
             {form.getInputProps(path).error ? (
-                <p className=" pt-1 pl-3 text-xs text-gray-600 saturate-[80%]">
-                    *{form.getInputProps(path).error}
-                </p>
+                <p className="error">*{form.getInputProps(path).error}</p>
             ) : null}
         </div>
     )

--- a/src/modules/protocol/elements/inputs/input.tsx
+++ b/src/modules/protocol/elements/inputs/input.tsx
@@ -23,9 +23,7 @@ const Input = ({
                 autoComplete="off"
             />
             {form.getInputProps(path).error ? (
-                <p className=" pl-3 pt-1 text-xs text-gray-600 saturate-[80%]">
-                    *{form.getInputProps(path).error}
-                </p>
+                <p className="error">*{form.getInputProps(path).error}</p>
             ) : null}
         </div>
     )

--- a/src/modules/protocol/elements/inputs/multiple-select.tsx
+++ b/src/modules/protocol/elements/inputs/multiple-select.tsx
@@ -54,7 +54,7 @@ export default function MultipleSelect({
                         </div>
                     </Combobox.Button>
                     {form.getInputProps(path).error ? (
-                        <p className=" pl-3 pt-1 text-xs text-gray-600 saturate-[80%]">
+                        <p className="error">
                             *{form.getInputProps(path).error}
                         </p>
                     ) : null}

--- a/src/modules/protocol/elements/inputs/number-input.tsx
+++ b/src/modules/protocol/elements/inputs/number-input.tsx
@@ -24,9 +24,7 @@ const NumberInput = ({
                 autoComplete="off"
             />
             {form.getInputProps(path).error ? (
-                <p className=" pt-1 pl-3 text-xs text-gray-600 saturate-[80%]">
-                    *{form.getInputProps(path).error}
-                </p>
+                <p className="error">*{form.getInputProps(path).error}</p>
             ) : null}
         </div>
     )

--- a/src/modules/protocol/elements/inputs/select.tsx
+++ b/src/modules/protocol/elements/inputs/select.tsx
@@ -66,7 +66,7 @@ export default function Select({
                         </div>
                     </Combobox.Button>
                     {form.getInputProps(path).error ? (
-                        <p className=" pl-3 pt-1 text-xs text-gray-600 saturate-[80%]">
+                        <p className="error">
                             *{form.getInputProps(path).error}
                         </p>
                     ) : null}

--- a/src/modules/protocol/elements/inputs/textarea.tsx
+++ b/src/modules/protocol/elements/inputs/textarea.tsx
@@ -10,9 +10,7 @@ const Textarea = ({ path, label }: { path: string; label: string }) => {
             <label className="label">{label}</label>
             <Tiptap {...form.getInputProps(path)} />
             {form.getInputProps(path).error ? (
-                <p className=" pt-1 pl-3 text-xs text-gray-600 saturate-[80%]">
-                    *{form.getInputProps(path).error}
-                </p>
+                <p className="error">*{form.getInputProps(path).error}</p>
             ) : null}
         </div>
     )

--- a/src/modules/protocol/protocol-form-template.tsx
+++ b/src/modules/protocol/protocol-form-template.tsx
@@ -6,6 +6,7 @@ import {
     ChevronLeft,
     ChevronRight,
     CircleCheck,
+    CircleDashed,
     X,
 } from 'tabler-icons-react'
 import { useNotifications } from '@mantine/notifications'
@@ -28,6 +29,7 @@ import {
     PublicationForm,
     BibliographyForm,
 } from '@protocol/form-sections'
+import InfoTooltip from './elements/tooltip'
 
 const sectionMapper: { [key: number]: JSX.Element } = {
     0: <IdentificationForm />,
@@ -192,6 +194,29 @@ export default function ProtocolForm({ protocol }: { protocol: ProtocolZod }) {
                 }}
                 className="w-full px-4"
             >
+                <InfoTooltip className="fixed">
+                    <div>
+                        <h4>Indicadores de sección</h4>
+                        <p>
+                            <CircleCheck className="mr-2 inline h-4 w-4 stroke-success-500 stroke-2" />
+                            Indica que la sección se encuentra completada y sin
+                            errores. Cuando todas las secciones tengan este
+                            indicador, se permite publicar un protocolo.
+                        </p>
+                        <p>
+                            <AlertCircle className="mr-2 inline h-4 w-4 stroke-warning-500 stroke-2" />
+                            Indica que la sección fue modificada pero necesita
+                            ser completada correctamente, falta algún campo
+                            obligatorio o tiene algún error.
+                        </p>
+                        <p>
+                            <CircleDashed className="mr-2 inline h-4 w-4 stroke-gray-500 opacity-40" />
+                            Si la sección se encuentra con menor opacidad, es
+                            porque no fue modificada en la session activa, pero
+                            se encuentra incompleta.
+                        </p>
+                    </div>
+                </InfoTooltip>
                 <motion.div
                     initial={{ opacity: 0, y: -7 }}
                     animate={{ opacity: 1, y: 0 }}

--- a/src/modules/protocol/protocol-form-template.tsx
+++ b/src/modules/protocol/protocol-form-template.tsx
@@ -1,6 +1,13 @@
 'use client'
 import { ProtocolProvider, useProtocol } from 'utils/createContext'
-import { Check, ChevronLeft, ChevronRight, X } from 'tabler-icons-react'
+import {
+    AlertCircle,
+    Check,
+    ChevronLeft,
+    ChevronRight,
+    CircleCheck,
+    X,
+} from 'tabler-icons-react'
 import { useNotifications } from '@mantine/notifications'
 import { Button } from '@elements/button'
 import { useCallback, useEffect, useState, useTransition } from 'react'
@@ -117,6 +124,38 @@ export default function ProtocolForm({ protocol }: { protocol: ProtocolZod }) {
         [notifications, router, section]
     )
 
+    const SegmentLabel = useCallback(
+        ({
+            path,
+            label,
+            value,
+        }: {
+            path: string
+            label: string
+            value: string
+        }) => (
+            <span className={'flex gap-1'}>
+                <span
+                    className={
+                        !form.isValid(path) && section !== value
+                            ? 'opacity-50'
+                            : ''
+                    }
+                >
+                    {label}
+                </span>
+                {!form.isValid(path) ? (
+                    form.isDirty(path) ? (
+                        <AlertCircle className="h-4 w-4 stroke-warning-500 stroke-2" />
+                    ) : null
+                ) : (
+                    <CircleCheck className="h-4 w-4 stroke-success-500 stroke-2" />
+                )}
+            </span>
+        ),
+        [form, section]
+    )
+
     return (
         <ProtocolProvider form={form}>
             <form
@@ -163,19 +202,91 @@ export default function ProtocolForm({ protocol }: { protocol: ProtocolZod }) {
                         value={section}
                         onChange={setSection}
                         data={[
-                            { label: 'Identificación', value: '0' },
-                            { label: 'Duración', value: '1' },
-                            { label: 'Presupuesto', value: '2' },
-                            { label: 'Descripción', value: '3' },
-                            { label: 'Introducción', value: '4' },
-                            { label: 'Metodología', value: '5' },
-                            { label: 'Publicación', value: '6' },
-                            { label: 'Bibliografía', value: '7' },
+                            {
+                                label: (
+                                    <SegmentLabel
+                                        path={'sections.identification'}
+                                        label={'Identificación'}
+                                        value={'0'}
+                                    />
+                                ),
+                                value: '0',
+                            },
+                            {
+                                label: (
+                                    <SegmentLabel
+                                        path={'sections.duration'}
+                                        label={'Duración'}
+                                        value={'1'}
+                                    />
+                                ),
+                                value: '1',
+                            },
+                            {
+                                label: (
+                                    <SegmentLabel
+                                        path={'sections.budget'}
+                                        label={'Presupuesto'}
+                                        value={'2'}
+                                    />
+                                ),
+                                value: '2',
+                            },
+                            {
+                                label: (
+                                    <SegmentLabel
+                                        path={'sections.description'}
+                                        label={'Descripción'}
+                                        value={'3'}
+                                    />
+                                ),
+                                value: '3',
+                            },
+                            {
+                                label: (
+                                    <SegmentLabel
+                                        path={'sections.introduction'}
+                                        label={'Introducción'}
+                                        value={'4'}
+                                    />
+                                ),
+                                value: '4',
+                            },
+                            {
+                                label: (
+                                    <SegmentLabel
+                                        path={'sections.methodology'}
+                                        label={'Metodología'}
+                                        value={'5'}
+                                    />
+                                ),
+                                value: '5',
+                            },
+                            {
+                                label: (
+                                    <SegmentLabel
+                                        path={'sections.publication'}
+                                        label={'Publicación'}
+                                        value={'6'}
+                                    />
+                                ),
+                                value: '6',
+                            },
+                            {
+                                label: (
+                                    <SegmentLabel
+                                        path={'sections.bibliography'}
+                                        label={'Bibliografía'}
+                                        value={'7'}
+                                    />
+                                ),
+                                value: '7',
+                            },
                         ]}
                         classNames={{
                             root: 'bg-gray-50 border rounded',
-                            label: 'uppercase text-xs px-2 py-1 font-light',
-                            indicator: 'bg-primary font-semibold',
+                            label: 'uppercase text-xs px-2 py-1 font-regular rounded flex gap-1',
+                            indicator: 'bg-primary rounded',
                         }}
                         color="blue"
                         transitionDuration={300}

--- a/src/modules/review/elements/review-form.tsx
+++ b/src/modules/review/elements/review-form.tsx
@@ -108,7 +108,7 @@ export default function ReviewForm({
                 <label className="label">Observación</label>
                 <Tiptap {...form.getInputProps('data')} />
                 {form.getInputProps('data').error ? (
-                    <p className=" pl-3 pt-1 text-xs text-gray-600 saturate-[80%]">
+                    <p className="error">
                         *{form.getInputProps('data').error}
                     </p>
                 ) : null}

--- a/src/repositories/review.ts
+++ b/src/repositories/review.ts
@@ -74,7 +74,7 @@ export const updateReview = async (data: Review) => {
         })
         return review
     } catch (error) {
-        return console.log(error)
+        return null
     }
 }
 

--- a/src/utils/zod/index.ts
+++ b/src/utils/zod/index.ts
@@ -245,7 +245,11 @@ export const DurationSchema = z.object({
                     .min(1, { message: 'El campo no puede estar vacío' }),
                 data: z
                     .object({
-                        task: z.string().min(1, { message: 'Cannot be empty' }),
+                        task: z
+                            .string()
+                            .min(1, {
+                                message: 'El campo no puede estar vació',
+                            }),
                     })
                     .array(),
             })
@@ -288,15 +292,19 @@ export const IdentificationSchema = z.object({
         )
         .array()
         .min(1, { message: 'Debe tener al menos un integrante' })
-        .refine((value) => {
-            //Al menos un integrante debe tener el rol de Director,
-            const hasDirector = value.some(team => team.role === 'Director')
-            console.log(hasDirector);
+        .refine(
+            (value) => {
+                //Al menos un integrante debe tener el rol de Director,
+                const hasDirector = value.some(
+                    (team) => team.role === 'Director'
+                )
+                console.log(hasDirector)
 
-            if (!hasDirector) return false
-            return true
-        }, { message: 'Debe tener al menos un Director' })
-
+                if (!hasDirector) return false
+                return true
+            },
+            { message: 'Debe tener al menos un Director' }
+        ),
 })
 
 /////////////////////////////////////////


### PR DESCRIPTION
## Hi folks

_This PR attempts to provide a better UX for not so enlightened users_

So qwik rundown of what was done:

1. Added a new css class ".error" and replaced it for every input (bottom error) and changed the text to red (error-500 in our app)
2. Added segment icon/indicator control, according to form values.  Meaning, if is valid, incomplete or dirty with errors. This distinction between incomplete and dirty with errors, is one to not be invasive on first load of the protocol. But as soon as the user interacts, he knows if section is missing data or something.
3. Added a tooltip to explain this to the users that might wonder what those icons mean.

** Thank you ** 
Have a lovely day.