### PR TITLE
Feature/pq 142 add fields to budget

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "@react-pdf/renderer": "^3.1.9",
         "@tabler/icons": "^2.15.0",
         "@tailwindcss/forms": "^0.5.3",
+        "@tiptap/extension-character-count": "^2.0.3",
         "@tiptap/extension-text-align": "2.0.0-beta.220",
         "@tiptap/pm": "^2.0.3",
         "@tiptap/react": "2.0.0-beta.220",

--- a/src/app/api/email/route.ts
+++ b/src/app/api/email/route.ts
@@ -1,0 +1,25 @@
+/* eslint-disable @next/next/no-server-import-in-page */
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+import nodemailer from 'nodemailer'
+
+export async function POST(request: NextRequest) {
+    const { email, message } = await request.json()
+
+    console.log(email, message)
+
+    const transporter = nodemailer.createTransport({
+        host: 'smtp.uap.edu.ar',
+        port: 25,
+    })
+
+    transporter.verify(function (error, success) {
+        if (error) {
+            console.log(error)
+        } else {
+            console.log('Server is ready to take our messages', success)
+        }
+    })
+
+    return NextResponse.json(request, { status: 201 })
+}

--- a/src/modules/elements/tiptap.tsx
+++ b/src/modules/elements/tiptap.tsx
@@ -4,6 +4,8 @@ import type { Editor } from '@tiptap/react'
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import clsx from 'clsx'
+import CharacterCount from '@tiptap/extension-character-count'
+
 import {
     ArrowBackUp,
     Bold,
@@ -35,6 +37,7 @@ const Tiptap = ({
             TextAlign.configure({
                 types: ['heading', 'paragraph'],
             }),
+            CharacterCount
         ],
         editorProps: {
             attributes: {
@@ -53,6 +56,10 @@ const Tiptap = ({
                 onBlur={() => onChange(editor.getHTML().replace('<p></p>', ''))}
                 editor={editor}
             />
+            <div className='absolute bottom-1 px-3 right-0 text-black/30'>
+            {editor.storage.characterCount.words() <= 1 && editor.storage.characterCount.words() !==0 ?  <>{editor.storage.characterCount.words()} palabra</> : <>{editor.storage.characterCount.words()} palabras</>}
+            </div>
+
         </div>
     )
 }

--- a/src/modules/protocol/elements/inputs/currency-input.tsx
+++ b/src/modules/protocol/elements/inputs/currency-input.tsx
@@ -32,12 +32,29 @@ const CurrencyInput = ({
                     .value.toString()
                     .replace(/\D/g, '')
                     .replace(/\B(?=(\d{3})+(?!\d))/g, '.')}
-                onChange={(e) =>
+                onChange={(e) =>{
+                    if(isNaN(form.getInputProps(path).value)){
+                       return form.setFieldValue(path, 0)
+                    }
                     form.setFieldValue(
                         path,
-                        parseInt(e.target.value.replace(/\./g, ''))
+                        parseInt(e.target.value.replace(/\./g, '').replace(/\^$/, "0"))
                     )
+                    
+                   
                 }
+                }
+
+             
+                onBlur={()=>{
+                    if(isNaN(form.getInputProps(path).value)){
+                        form.setFieldValue(path, 0)
+                    }
+                    
+                }}
+
+                
+
                 className="input pl-6"
                 placeholder={label}
                 autoComplete="off"

--- a/src/modules/protocol/elements/inputs/input-list.tsx
+++ b/src/modules/protocol/elements/inputs/input-list.tsx
@@ -74,6 +74,16 @@ export function InputList(props: {
     )
 }
 
+/** Helper function that replaces the number of the row or whatever from the deepPushValue so that the trash button can properly target the value it needs to delete.
+ *
+ * E.g:
+ *
+ * Let's say we have this string => sections.budget.expenses1.data
+ *
+ * This function will convert it to the following string => sections.budget.expenses.1.data
+ *
+ * It simply added a dot before the number.
+ */
 function replaceString(input: string) {
     const number = input.slice(-6, -5)
     const newString = input.replace(number, `.${number}`)

--- a/src/modules/protocol/elements/inputs/input-list.tsx
+++ b/src/modules/protocol/elements/inputs/input-list.tsx
@@ -74,6 +74,12 @@ export function InputList(props: {
     )
 }
 
+function replaceString(input: string) {
+    const number = input.slice(-6, -5)
+    const newString = input.replace(number, `.${number}`)
+    return newString
+}
+
 function PreprocessFieldsMap({
     fieldsToMap,
     path,
@@ -126,7 +132,11 @@ function PreprocessFieldsMap({
 
             <Trash
                 onClick={() => {
-                    form.removeListItem(path + deepPushPath, index)
+                    console.log(path + replaceString(deepPushPath))
+                    form.removeListItem(
+                        path + replaceString(deepPushPath),
+                        index
+                    )
                 }}
                 className={`mt-[2.2rem] h-5 flex-shrink cursor-pointer self-start text-primary hover:text-base-400 active:scale-[0.90] ${
                     index == 0 && !isBudget

--- a/src/modules/protocol/elements/inputs/input-list.tsx
+++ b/src/modules/protocol/elements/inputs/input-list.tsx
@@ -40,6 +40,7 @@ export function InputList(props: {
     newLeafItemValue: LeafItemProps
     preprocessKey?: string
     footer?: React.ReactNode
+    isBudget?: boolean
 }) {
     const form = useProtocolContext()
 
@@ -61,6 +62,7 @@ export function InputList(props: {
                             {...props}
                             fieldsToMap={array}
                             deepPushPath={`${i}.data`}
+                            isBudget={props.isBudget}
                         />
                     </>
                 ))
@@ -78,12 +80,14 @@ function PreprocessFieldsMap({
     headers,
     newLeafItemValue,
     deepPushPath = '',
+    isBudget,
 }: {
     path: string
     fieldsToMap: (string | number)[]
     headers: Header[]
     newLeafItemValue: LeafItemProps
     deepPushPath?: string
+    isBudget?: boolean
 }) {
     const form = useProtocolContext()
 
@@ -121,9 +125,13 @@ function PreprocessFieldsMap({
             ))}
 
             <Trash
-                onClick={() => form.removeListItem(path + deepPushPath, index)}
+                onClick={() => {
+                    form.removeListItem(path + deepPushPath, index)
+                }}
                 className={`mt-[2.2rem] h-5 flex-shrink cursor-pointer self-start text-primary hover:text-base-400 active:scale-[0.90] ${
-                    index == 0 ? 'pointer-events-none invisible' : ''
+                    index == 0 && !isBudget
+                        ? 'pointer-events-none invisible'
+                        : ''
                 }`}
             />
         </div>

--- a/src/modules/protocol/elements/inputs/input-list.tsx
+++ b/src/modules/protocol/elements/inputs/input-list.tsx
@@ -39,6 +39,7 @@ export function InputList(props: {
     headers: Header[]
     newLeafItemValue: LeafItemProps
     preprocessKey?: string
+    footer?: React.ReactNode
 }) {
     const form = useProtocolContext()
 
@@ -66,6 +67,7 @@ export function InputList(props: {
             ) : (
                 <FieldsMap {...props} fieldsToMap={data} />
             )}
+            {props.footer}
         </InputListWrapper>
     )
 }

--- a/src/modules/protocol/elements/item-list-view.tsx
+++ b/src/modules/protocol/elements/item-list-view.tsx
@@ -35,12 +35,12 @@ const ItemListView = ({ data, footer }: ItemListProps) => {
                                 </span>
 
                                 {item.data.map((row, index) => (
-                                    <ListRow data={row} key={index} />
+                                    <ListRow data={row} key={index}/>
+                                    
                                 ))}
                             </div>
                         ))}
                     </div>
-
                 </dd>
             ) : (
                 <EmptyStateItem />

--- a/src/modules/protocol/elements/item-list-view.tsx
+++ b/src/modules/protocol/elements/item-list-view.tsx
@@ -11,8 +11,9 @@ interface ItemListProps {
         values?: ListRowValues[]
         deepValues?: DeepValue[]
     }
+    footer?: React.ReactNode
 }
-const ItemListView = ({ data }: ItemListProps) => {
+const ItemListView = ({ data, footer }: ItemListProps) => {
     return (
         <div className="sm:col-span-2">
             <dt className="text-sm font-medium text-gray-500">{data.title}</dt>
@@ -39,10 +40,12 @@ const ItemListView = ({ data }: ItemListProps) => {
                             </div>
                         ))}
                     </div>
+
                 </dd>
             ) : (
                 <EmptyStateItem />
             )}
+            {footer}
         </div>
     )
 }

--- a/src/modules/protocol/elements/item-view.tsx
+++ b/src/modules/protocol/elements/item-view.tsx
@@ -7,12 +7,13 @@ interface ShortDataProps {
 const ItemView = ({ title, value }: ShortDataProps) => {
     return (
         <div className="sm:col-span-1">
-            <dt className="text-sm font-medium text-gray-500">{title}</dt>
+            {title === "Materia" && value.length <= 0 ? null : <><dt className="text-sm font-medium text-gray-500">{title}</dt>
             {value ? (
                 <dd className="mt-1 text-sm text-gray-900">{value}</dd>
             ) : (
                 <EmptyStateItem />
-            )}
+            )}</>}
+           
         </div>
     )
 }

--- a/src/modules/protocol/form-sections/budget-form.tsx
+++ b/src/modules/protocol/form-sections/budget-form.tsx
@@ -43,19 +43,27 @@ export function BudgetForm() {
                             ),
                         },
                     ]}
-                    footer={<div className='flex gap-2 py-4 ml-auto w-fit text-xl mr-4'><p className='text-gray-400'>Total: </p> ${form.values.sections.budget.expenses.reduce((acc, val) => {
-                        return (
-                            acc +
-                            val.data.reduce((prev, curr) => {
-                                
-                                if(isNaN(curr.amount)) curr.amount = 0
-                                else curr.amount
-                                return prev + curr.amount;
-                            }, 0) 
-                        )
-                    }, 0).toString().replace(/\B(?=(\d{3})+(?!\d))/g, '.')}</div>}
+                    footer={
+                        <div className="ml-auto mr-4 flex w-fit gap-2 py-4 text-xl">
+                            <p className="text-gray-400">Total: </p> $
+                            {form.values.sections.budget.expenses
+                                .reduce((acc, val) => {
+                                    return (
+                                        acc +
+                                        val.data.reduce((prev, curr) => {
+                                            if (isNaN(curr.amount))
+                                                curr.amount = 0
+                                            else curr.amount
+                                            return prev + curr.amount
+                                        }, 0)
+                                    )
+                                }, 0)
+                                .toString()
+                                .replace(/\B(?=(\d{3})+(?!\d))/g, '.')}
+                        </div>
+                    }
+                    isBudget={true}
                 />
-                
             </>
         </motion.div>
     )

--- a/src/modules/protocol/form-sections/budget-form.tsx
+++ b/src/modules/protocol/form-sections/budget-form.tsx
@@ -43,7 +43,19 @@ export function BudgetForm() {
                             ),
                         },
                     ]}
+                    footer={<div className='flex gap-2 py-4 ml-auto w-fit text-xl mr-4'><p className='text-gray-400'>Total: </p> ${form.values.sections.budget.expenses.reduce((acc, val) => {
+                        return (
+                            acc +
+                            val.data.reduce((prev, curr) => {
+                                
+                                if(isNaN(curr.amount)) curr.amount = 0
+                                else curr.amount
+                                return prev + curr.amount;
+                            }, 0) 
+                        )
+                    }, 0).toString().replace(/\B(?=(\d{3})+(?!\d))/g, '.')}</div>}
                 />
+                
             </>
         </motion.div>
     )

--- a/src/modules/protocol/protocol-form-template.tsx
+++ b/src/modules/protocol/protocol-form-template.tsx
@@ -59,8 +59,12 @@ export default function ProtocolForm({ protocol }: { protocol: ProtocolZod }) {
         validateInputOnChange: true,
     })
 
+
+
+
     useEffect(() => {
         // Validate if not existing path goes to section 0
+        
         if (
             path &&
             !['0', '1', '2', '3', '4', '5', '6', '7'].includes(

--- a/src/modules/protocol/view-sections/budget-view.tsx
+++ b/src/modules/protocol/view-sections/budget-view.tsx
@@ -20,17 +20,18 @@ const BudgetView = ({ data }: BudgetViewProps) => {
                             down: item.detail,
                             inverted: true,
                         },
+                       
+                        {
+                            up: 'Año',
+                            down: item.year,
+                            inverted: true,
+                        },
                         {
                             up: 'Monto',
                             down: `$${item.amount}`.replace(
                                 /\B(?=(\d{3})+(?!\d))/g,
                                 '.'
                             ),
-                            inverted: true,
-                        },
-                        {
-                            up: 'Año',
-                            down: item.year,
                             inverted: true,
                         },
                     ])
@@ -45,7 +46,18 @@ const BudgetView = ({ data }: BudgetViewProps) => {
             title="Presupuesto"
             description="Detalles del presupuesto"
         >
-            <ItemListView data={tableData} />
+            <ItemListView data={tableData} footer={<div className='flex gap-2 py-4 ml-auto w-fit text-xl mr-4'><p className='text-gray-400'>Total: </p> ${data.expenses.reduce((acc, val) => {
+                        return (
+                            acc +
+                            val.data.reduce((prev, curr) => {
+                                
+                                if(isNaN(curr.amount)) curr.amount = 0
+                                else curr.amount
+                                return prev + curr.amount;
+                            }, 0) 
+                        )
+                    }, 0).toString().replace(/\B(?=(\d{3})+(?!\d))/g, '.')}</div>} />
+            
         </SectionViewer>
     )
 }

--- a/src/utils/createContext.ts
+++ b/src/utils/createContext.ts
@@ -27,18 +27,18 @@ export const initialSectionValues: Sections = {
     },
     budget: {
         expenses: [
-            { type: 'Insumos', data: [{ detail: '', amount: 0, year: '' }] },
-            { type: 'Libros', data: [{ detail: '', amount: 0, year: '' }] },
+            { type: 'Insumos', data: [] },
+            { type: 'Libros', data: [] },
             {
                 type: 'Materiales de Impresión',
-                data: [{ detail: '', amount: 0, year: '' }],
+                data: [],
             },
-            { type: 'Viajes', data: [{ detail: '', amount: 0, year: '' }] },
+            { type: 'Viajes', data: [] },
             {
                 type: 'Gastos por publicación',
-                data: [{ detail: '', amount: 0, year: '' }],
+                data: [],
             },
-            { type: 'Otros', data: [{ detail: '', amount: 0, year: '' }] },
+            { type: 'Otros', data: [] },
         ],
     },
     description: {

--- a/src/utils/zod/index.ts
+++ b/src/utils/zod/index.ts
@@ -145,7 +145,28 @@ export const SectionsSchema = z.object({
     introduction: z.lazy(() => IntroductionSchema),
     methodology: z.lazy(() => MethodologySchema),
     publication: z.lazy(() => PublicationSchema),
-})
+}).refine(
+    (value) =>{
+        //Check if the protocol (investigation project) is of PIC type. If it is, enforce the "assignment" field in the validation. If it isn't, it's an optional field.
+        if(value.duration.modality === "Proyecto de investigación desde las cátedras (PIC)"){
+            if(value.identification.assignment)
+                if(value.identification.assignment.length <= 0) return false
+                else{
+                    return true
+                }
+        }
+        else{
+            return true
+        }
+    },
+        
+    {
+        message: 'Campo requerido',
+        path: ['identification', 'assignment'],
+    }
+)
+
+
 
 export type Sections = z.infer<typeof SectionsSchema>
 
@@ -256,7 +277,7 @@ export const DurationSchema = z.object({
 
 export const IdentificationSchema = z.object({
     assignment: z.string().optional(),
-    career: z.string().min(1, { message: 'El campo no puede estar vacío' }),
+    career: z.string().min(1, "El campo no puede estar vacío"),
     sponsor: z.string().array(),
     title: z.string().min(6, { message: 'Debe tener al menos 6 caracteres' }),
     team: z
@@ -298,6 +319,9 @@ export const IdentificationSchema = z.object({
             { message: 'Debe tener al menos un Director' }
         ),
 })
+
+
+
 
 /////////////////////////////////////////
 // PROTOCOL SECTIONS INTRODUCTION SCHEMA

--- a/src/utils/zod/index.ts
+++ b/src/utils/zod/index.ts
@@ -191,13 +191,8 @@ export const BudgetSchema = z.object({
                         detail: z.string().min(1, {
                             message: 'El campo no puede estar vacío',
                         }),
-                        amount: z
-                            .number({
-                                invalid_type_error:
-                                    'Este campo debe ser numérico',
-                            })
-                            .positive({ message: 'Debe ser mayor que cero' }),
-                        year: z.string().min(1, {
+                        amount: z.any(),
+                        year: z.string().min(0, {
                             message: 'El campo no puede estar vacío',
                         }),
                     })
@@ -296,7 +291,6 @@ export const IdentificationSchema = z.object({
                 const hasDirector = value.some(
                     (team) => team.role === 'Director'
                 )
-                console.log(hasDirector)
 
                 if (!hasDirector) return false
                 return true


### PR DESCRIPTION
A few additions have been made:
<img width="896" alt="image" src="https://github.com/bojkomatias/uap-vid/assets/50425596/88c2acae-5cf6-44d9-8789-38eb831d6246">

1. Added the total to the budget view and budget form.
<img width="1247" alt="image" src="https://github.com/bojkomatias/uap-vid/assets/50425596/278a08bc-fb7d-42ec-b1f0-a2d3f3b7d2ea">
<img width="1247" alt="image" src="https://github.com/bojkomatias/uap-vid/assets/50425596/21716e51-20b6-42e0-acdc-1e4fdf809d97">

2. Added a word count to the TipTap text editor
<img width="1247" alt="image" src="https://github.com/bojkomatias/uap-vid/assets/50425596/41849673-43ff-4322-b10e-e32a0c2e1a88">

3. There isn't a default line for each type of expense in the budget anymore. Now we only add lines that we want, if there's an expense type that doesn't apply to the investigation project, it remains empty.
<img width="1247" alt="image" src="https://github.com/bojkomatias/uap-vid/assets/50425596/3991c3dd-424c-4da0-b82c-831abf36898c">

4. Added a custom validation for "materia" in zod. Now "materia" is only a required  field if the project type is "PIC". If it isn't, it's optional.

