### PR TITLE
Hotfix/guardar

### DIFF
--- a/src/modules/protocol/protocol-form-template.tsx
+++ b/src/modules/protocol/protocol-form-template.tsx
@@ -106,13 +106,14 @@ export default function ProtocolForm({ protocol }: { protocol: ProtocolZod }) {
                     message: 'El protocolo ha sido guardado con éxito',
                     intent: 'success',
                 })
+
                 //Timeout is for UX purposes
                 setTimeout(() => {
                     router.push(`/protocols/${protocol.id}`)
+                    startTransition(() => {
+                        router.refresh()
+                    })
                 }, 500)
-                startTransition(() => {
-                    router.refresh()
-                })
             }
         },
         [router, section]

--- a/src/modules/protocol/protocol-form-template.tsx
+++ b/src/modules/protocol/protocol-form-template.tsx
@@ -106,9 +106,10 @@ export default function ProtocolForm({ protocol }: { protocol: ProtocolZod }) {
                     message: 'El protocolo ha sido guardado con éxito',
                     intent: 'success',
                 })
-                startTransition(() => {
-                    router.refresh()
-                })
+                //Timeout is for UX purposes
+                setTimeout(() => {
+                    router.push(`/protocols/${protocol.id}`)
+                }, 500)
             }
         },
         [router, section]
@@ -272,14 +273,6 @@ export default function ProtocolForm({ protocol }: { protocol: ProtocolZod }) {
                             type="submit"
                             intent="secondary"
                             loading={isPending}
-                            onClick={() => {
-                                if (!path.includes('new'))
-                                    //Timeout is for UX purposes
-                                    setTimeout(() => {
-                                        router.push(`/protocols/${protocol.id}`)
-                                    }, 500)
-                                else return
-                            }}
                         >
                             Guardar
                         </Button>

--- a/src/modules/protocol/protocol-form-template.tsx
+++ b/src/modules/protocol/protocol-form-template.tsx
@@ -110,6 +110,9 @@ export default function ProtocolForm({ protocol }: { protocol: ProtocolZod }) {
                 setTimeout(() => {
                     router.push(`/protocols/${protocol.id}`)
                 }, 500)
+                startTransition(() => {
+                    router.refresh()
+                })
             }
         },
         [router, section]


### PR DESCRIPTION
### _Hotfix_

### **Problema**:
Se había llegado a la conclusión de usar un router.push una vez que se guardan los protocolos para volver a la vista del protocolo, saliendo así de la vista de edición. El problema radica en que el push se estaba haciendo siempre que se apretaba el botón "Guardar".
###  **Fix**:
Moví el router.push al if que hace el handling del estado 200 del response body. Ahora solo se hace el push una vez que la request es successful.