### PR TITLE
Cambio cantidad de semanas en meses y en un año

### DIFF
--- a/src/modules/anual-budget/budget-team-member-fees.tsx
+++ b/src/modules/anual-budget/budget-team-member-fees.tsx
@@ -12,6 +12,7 @@ import { cx } from '@utils/cx'
 import { currencyFormatter } from '@utils/formatters'
 import BudgetExecutionView from './execution/budget-execution-view'
 import { useRouter } from 'next/navigation'
+import type { WEEKS_IN_HALF_YEAR, WEEKS_IN_YEAR } from '@utils/constants'
 
 export function BudgetTeamMemberFees({
     editable,
@@ -24,7 +25,7 @@ export function BudgetTeamMemberFees({
     budgetTeamMembers: AnualBudgetTeamMemberWithAllRelations[]
     ABTe: number
     ABTr: number
-    duration: 52 | 26
+    duration: typeof WEEKS_IN_YEAR | typeof WEEKS_IN_HALF_YEAR
 }) {
     const router = useRouter()
     const form = useForm({ initialValues: budgetTeamMembers })

--- a/src/modules/anual-budget/budget-view.tsx
+++ b/src/modules/anual-budget/budget-view.tsx
@@ -11,6 +11,7 @@ import { currencyFormatter } from '@utils/formatters'
 import { BudgetTeamMemberFees } from './budget-team-member-fees'
 import { BudgetItems } from './budget-items'
 import { Badge } from '@elements/badge'
+import type { WEEKS_IN_YEAR, WEEKS_IN_HALF_YEAR } from '../../utils/constants';
 
 export function BudgetView({
     budgetId,
@@ -23,7 +24,7 @@ export function BudgetView({
 }: {
     budgetId: string
     state: AnualBudgetState
-    duration: 52 | 26
+    duration: typeof WEEKS_IN_YEAR | typeof WEEKS_IN_HALF_YEAR
     budgetItems: AnualBudgetItem[]
     budgetTeamMembers: AnualBudgetTeamMemberWithAllRelations[]
     calculations: TotalBudgetCalculation

--- a/src/utils/anual-budget/protocol-duration.ts
+++ b/src/utils/anual-budget/protocol-duration.ts
@@ -1,10 +1,10 @@
-import { PROTOCOL_DURATION_DEFAULT } from '@utils/constants'
+import { PROTOCOL_DURATION_DEFAULT, WEEKS_IN_HALF_YEAR, WEEKS_IN_YEAR } from '@utils/constants'
 
 /** Returns the procol duration in weeks
  *
- * If duration is "12 months", the function will return 52.
+ * If duration is "12 months", the function will return 48.
  *
- * If duration is "6 months", the function will return 26.
+ * If duration is "6 months", the function will return 24.
  *
  * If duration is an empty string or doesn't contain a space, the function will use the PROTOCOL_DURATION_DEFAULT value and compare it with 12 to determine the return value.
  */
@@ -12,5 +12,5 @@ export const protocolDuration = (duration: string) =>
     parseInt(
         duration.split(' ').at(0) || PROTOCOL_DURATION_DEFAULT.toString()
     ) >= 12
-        ? 52
-        : 26
+        ? WEEKS_IN_YEAR
+        : WEEKS_IN_HALF_YEAR

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,2 +1,4 @@
 export const PROTOCOL_DURATION_DEFAULT=12
-export const WEEKS_IN_MONTH = 52/12
+export const WEEKS_IN_MONTH = 4
+export const WEEKS_IN_HALF_YEAR = 24
+export const WEEKS_IN_YEAR = 48


### PR DESCRIPTION
**Para estandarizar el cálculo de horas, se decidió utilizar 4 semanas por mes.**
El cambio implica también llevar el cálculo de 52 semanas por año a 48.
Este cambio se debe a que la VID quiere manejar números más "redondos".
En caso de ser necesario modificar el total de horas, se hará de forma manual editando el total de horas en el presupuesto antes de ser aprobado.

Los tests que habíamos hecho nosotros nos dieron bien porque justo eran todos obreros, y cuando son obreros recursos humanos y finanzas hacen el cálculo con 13 semanas para incluir el aguinaldo, por eso usaban 52 semanas (13 * 4).
De todas maneras, con la feature que agregué yo hace un par de semanas para que se pueda modificar la cantidad de meses que trabaja la persona, esto está resuelto también.