### PR TITLE
Feature/pq 263 actualizar preguntas de evaluacion

### DIFF
--- a/src/modules/review/elements/review-form.tsx
+++ b/src/modules/review/elements/review-form.tsx
@@ -16,7 +16,16 @@ import { questions as rawQuestions } from 'config/review-questions'
 
 export default function ReviewForm({ review }: { review: Review }) {
     const form = useReview({
-        initialValues: review,
+        initialValues: {
+            ...review,
+            //This filter passes only the active questions to the form values.
+            questions: review.questions.filter((q) => {
+                const questionInfo = rawQuestions.find(
+                    (rQuestion) => rQuestion.id === q.id
+                )
+                return questionInfo ? questionInfo.active : false
+            }),
+        },
         validate: zodResolver(ReviewSchema),
         validateInputOnChange: true,
     })
@@ -57,34 +66,27 @@ export default function ReviewForm({ review }: { review: Review }) {
             <h3 className="ml-2 text-lg font-semibold text-gray-900">
                 Realizar revisión
             </h3>
+
             <ReviewProvider form={form}>
                 <form
                     onSubmit={(e) => {
                         e.preventDefault()
                         addReview({
                             ...form.values,
+
                             revised: false,
                             updatedAt: new Date(),
                         })
                     }}
                 >
                     <div className="space-y-3 divide-y overflow-y-auto border-y bg-white px-2 pb-3">
-                        {form.values.questions
-                            .filter((q) => {
-                                const questionInfo = rawQuestions.find(
-                                    (rQuestion) => rQuestion.id === q.id
-                                )
-                                return questionInfo
-                                    ? questionInfo.active
-                                    : false
-                            })
-                            .map((q, index) => (
-                                <ReviewQuestion
-                                    key={q.id}
-                                    index={index}
-                                    id={q.id}
-                                />
-                            ))}
+                        {form.values.questions.map((q, index) => (
+                            <ReviewQuestion
+                                key={q.id}
+                                index={index}
+                                id={q.id}
+                            />
+                        ))}
                     </div>
                     <RadioGroup
                         {...form.getInputProps('verdict')}


### PR DESCRIPTION
As I mentioned in the commit, I was filtering the inactive questions only in the frontend, so the questions wouldn't show up to the user, but the form still had them in their values, so whenever the user submitted the review, it would post the old questions too.